### PR TITLE
Impliment initial go server by negroni+httprouter

### DIFF
--- a/risu.go
+++ b/risu.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/codegangsta/negroni"
+	"github.com/julienschmidt/httprouter"
+)
+
+func index(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	name := r.FormValue("name")
+	fmt.Fprintf(w, "Welcome, %s!\n", name)
+}
+
+func show(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	image := ps.ByName("image")
+	fmt.Fprintf(w, "Build %s!\n", image)
+}
+
+func main() {
+	router := httprouter.New()
+	router.GET("/", index)
+	router.GET("/build/:image", show)
+
+	n := negroni.Classic()
+	n.UseHandler(router)
+	n.Run(":8080")
+}


### PR DESCRIPTION
[negroni](https://github.com/codegangsta/negroni)と[httprouter](https://github.com/julienschmidt/httprouter)でサーバーのテンプレートを作った
- http://localhost:8080/?name=hoge
- http://localhost:8080/build/abc

それぞれにリクエストパラメータと(:id)的なやつの扱い方の例を含むようにした。

```
go get ./...
go run risu.go
```

で動くはず。

middlewareとしてnegroniは今までのサーベイの結果Goだったらこれでいいのかなと思っていて、Gorilla Muxは今まで使った経験からちょっとわかりにくさ(httprouterは:id的なマッチングは引数で渡るのに対し、Muxはリクエストから再取得する設計になっている)を感じていたのでhttprouterにしてみた。

これはもともとFlynで使われていて

https://github.com/flynn/flynn/blob/c5b7be8500043b934c37bbbcf13aa21c43d7c620/controller/controller.go

gorilla mux と比較したベンチマークでも優れていたのでこれでいいんじゃないかと思っている。

https://github.com/julienschmidt/go-http-routing-benchmark

Please Review!! @spesnova @koudaiii @dtan4 
