### PR TITLE
Registry

### DIFF
--- a/coreos/.env.sample
+++ b/coreos/.env.sample
@@ -7,3 +7,8 @@ TIMEZONE=Asia/Tokyo
 # Compose
 #
 COMPOSE_VERSION=1.3.3
+
+#
+# etcd
+#
+ETCD_DISCOVERY=

--- a/coreos/user-data.yml.erb
+++ b/coreos/user-data.yml.erb
@@ -4,6 +4,12 @@ coreos:
   update:
     group: beta
     reboot-strategy: off
+  etcd:
+    # generate a new token for each unique cluster from https://discovery.etcd.io/new
+    # WARNING: replace each time you 'vagrant destroy'
+    discovery: <%= ENV["ETCD_DISCOVERY"] %>
+    addr: $public_ipv4:4001
+    peer-addr: $public_ipv4:7001
   units:
     - name: settimezone.service
       command: start
@@ -15,6 +21,8 @@ coreos:
         ExecStart=/usr/bin/timedatectl set-timezone <%= ENV["TIMEZONE"] %>
         RemainAfterExit=yes
         Type=oneshot
+    - name: etcd.service
+      command: start
     - name: install-docker-compose.service
       command: start
       content: |

--- a/registry/etcd.go
+++ b/registry/etcd.go
@@ -1,0 +1,61 @@
+package registry
+
+import (
+	"code.google.com/p/go-uuid/uuid"
+	"github.com/coreos/go-etcd/etcd"
+
+	"github.com/wantedly/risu/schema"
+)
+
+const (
+	DefaultMachines  = "http://172.17.8.101:4001"
+	DefaultKeyPrefix = "/risu/"
+)
+
+type EtcdRegistry struct {
+	etcd      etcd.Client
+	keyPrefix string
+}
+
+func NewRegistry(machines string, keyPrefix string) *Registry {
+	if os.Getenv("RISU_ETCD_MACHINES") != "" {
+		machines = os.Getenv("RISU_ETCD_MACHINES")
+	}
+
+	if machines == "" {
+		machines = DefaultMachines
+	}
+
+	m := strings.Split(machines, ",")
+	etcdClient := *etcd.NewClient(m)
+	return &Registry{etcdClient, keyPrefix}
+}
+
+func (r *EtcdRegistry) Set(id uuid.UUID, build schema.Build) error {
+	return nil
+}
+
+func (r *EtcdRegistry) Get(id uuid.UUID) (schema.Build, error) {
+	return nil
+}
+
+func marshal(obj interface{}) (string, error) {
+	encoded, err := json.Marshal(obj)
+	if err != nil {
+		return "", fmt.Errorf("unable to JSON-serialize object: %s", err)
+	}
+	return string(encoded), nil
+}
+
+func unmarshal(val string, obj interface{}) error {
+	err := json.Unmarshal([]byte(val), &obj)
+	if err != nil {
+		return fmt.Errorf("unable to JSON-deserialize object: %s", err)
+	}
+	return nil
+}
+
+func isKeyNotFound(err error) bool {
+	e, ok := err.(*etcd.EtcdError)
+	return ok && e.ErrorCode == 100
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1,0 +1,11 @@
+package registry
+
+import (
+	"code.google.com/p/go-uuid/uuid"
+	"github.com/wantedly/risu/schema"
+)
+
+type Registry interface {
+	Set(id uuid.UUID, build schema.Build) error
+	Get(id uuid.UUID) (schema.Build, error)
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -6,6 +6,15 @@ import (
 )
 
 type Registry interface {
-	Set(id uuid.UUID, build schema.Build) error
+	Set(build schema.Build) error
 	Get(id uuid.UUID) (schema.Build, error)
+}
+
+func NewRegistry(backend string, endpoint string) Registry {
+	switch backend {
+	case "etcd":
+		return NewEtcdRegistry(endpoint)
+	default:
+		return NewEtcdRegistry(endpoint)
+	}
 }

--- a/risu.go
+++ b/risu.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"code.google.com/p/go-uuid/uuid"
+
+	"github.com/wantedly/risu/registry"
+	"github.com/wantedly/risu/schema"
+)
+
+func main() {
+	reg := registry.NewRegistry("etcd", "http://172.17.8.101:4001")
+
+	build := schema.Build{
+		ID:             uuid.NewUUID(),
+		SourceRepo:     "wantedly/risu",
+		SourceRevision: "2c004f60b47bac66a3a83ffe40b822629251c037",
+		Name:           "quay.io/wantedly/risu:latest",
+		Dockerfile:     "Dockerfile",
+	}
+
+	err := reg.Set(build)
+	if err != nil {
+		panic(err)
+	}
+
+	_, err = reg.Get(build.ID)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/schema/build.go
+++ b/schema/build.go
@@ -1,0 +1,17 @@
+package schema
+
+import (
+	"time"
+
+	"code.google.com/p/go-uuid/uuid"
+)
+
+type Build struct {
+	ID             uuid.UUID `json:"id"`
+	SourceRepo     string    `json:"source_repo"`
+	SourceRevision string    `json:"source_revision"`
+	Name           string    `json:"name"`
+	Dockerfile     string    `json:"dockerfile"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}


### PR DESCRIPTION
## WHAT

Implements registry as data store for build detail (includes build status).

NOTE: `risu.go` is dummy implementation. it just show how registry works.
## WHY

If we want to handle requests in parallel, we need to distinguish each builds.
