### PR TITLE
buildのリクエストを受ける

### DIFF
--- a/risu.go
+++ b/risu.go
@@ -1,12 +1,34 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 
 	"github.com/codegangsta/negroni"
 	"github.com/julienschmidt/httprouter"
 )
+
+// Build is "Create a new build.""
+type Build struct {
+	SourceRepo     string `json:"source_repo"`
+	SourceRevision string `json:"source_revision"`
+	Name           string `json:"name"`
+	Dockerfile     string `json:"dockerfile"`
+}
+
+func create(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	defer r.Body.Close()
+	build := &Build{Dockerfile: "Dockerfile"} // default setup Dockerfile
+	decoder := json.NewDecoder(r.Body)
+	err := decoder.Decode(&build)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Fprintln(w, build)
+}
 
 func index(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	name := r.FormValue("name")
@@ -21,7 +43,8 @@ func show(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 func main() {
 	router := httprouter.New()
 	router.GET("/", index)
-	router.GET("/build/:image", show)
+	router.GET("/builds/:image", show)
+	router.POST("/builds", create)
 
 	n := negroni.Classic()
 	n.UseHandler(router)

--- a/risu.go
+++ b/risu.go
@@ -5,22 +5,38 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"time"
 
+	"code.google.com/p/go-uuid/uuid"
 	"github.com/codegangsta/negroni"
 	"github.com/julienschmidt/httprouter"
+
 	"github.com/wantedly/risu/schema"
 )
 
 func create(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	defer r.Body.Close()
-	build := &schema.Build{Dockerfile: "Dockerfile"} // default setup Dockerfile
-	decoder := json.NewDecoder(r.Body)
-	err := decoder.Decode(&build)
+	var opts schema.BuildCreateOpts
+	err := json.NewDecoder(r.Body).Decode(&opts)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	fmt.Fprintln(w, build)
+	if opts.Dockerfile == "" {
+		opts.Dockerfile = "Dockerfile"
+	}
+
+	build := schema.Build{
+		ID:             uuid.NewUUID(),
+		SourceRepo:     opts.SourceRepo,
+		SourceRevision: opts.SourceRevision,
+		Name:           opts.Name,
+		Dockerfile:     opts.Dockerfile,
+		CreatedAt:      time.Now(),
+		UpdatedAt:      time.Now(),
+	}
+
+	fmt.Fprint(w, build)
 }
 
 func index(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {

--- a/risu.go
+++ b/risu.go
@@ -8,19 +8,12 @@ import (
 
 	"github.com/codegangsta/negroni"
 	"github.com/julienschmidt/httprouter"
+	"github.com/wantedly/risu/schema"
 )
-
-// Build is "Create a new build.""
-type Build struct {
-	SourceRepo     string `json:"source_repo"`
-	SourceRevision string `json:"source_revision"`
-	Name           string `json:"name"`
-	Dockerfile     string `json:"dockerfile"`
-}
 
 func create(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	defer r.Body.Close()
-	build := &Build{Dockerfile: "Dockerfile"} // default setup Dockerfile
+	build := &schema.Build{Dockerfile: "Dockerfile"} // default setup Dockerfile
 	decoder := json.NewDecoder(r.Body)
 	err := decoder.Decode(&build)
 	if err != nil {

--- a/schema/build.go
+++ b/schema/build.go
@@ -15,3 +15,10 @@ type Build struct {
 	CreatedAt      time.Time `json:"created_at"`
 	UpdatedAt      time.Time `json:"updated_at"`
 }
+
+type BuildCreateOpts struct {
+	SourceRepo     string `json:"source_repo"`
+	SourceRevision string `json:"source_revision"`
+	Name           string `json:"name"`
+	Dockerfile     string `json:"dockerfile"`
+}


### PR DESCRIPTION
## REF

https://github.com/wantedly/risu/blob/master/docs/api-v1-alpha.md
## WHY

buildの指示をAPI経由で行えるようにするため
## WHAT
- Schemeを元に、受け付けるJSONの型とParseを入れる
- Schemeに合わせて、buildからbuildsへroutesの変更
## Curl Example

```
$ curl -n -X POST https://<your-risu-server>.com/builds \
  -H "Content-Type: application/json" \
 \
  -d '{
  "source_repo": "wantedly/risu",
  "source_revision": "ada9ce1829fab49e605e5a563dbf91274f64e923",
  "name": "quay.io/wantedly/risu:latest",
  "dockerfile": "Dockerfile.dev"
}'
```
