### PR TITLE
Fix build error

### DIFF
--- a/cache/local_fs.go
+++ b/cache/local_fs.go
@@ -39,7 +39,7 @@ func (c *LocalFsCache) Get(key string) (string, error) {
 		return "", nil
 	}
 
-	if err = InflateTarGz(cache, inflateDir); err != nil {
+	if err := InflateTarGz(cache, inflateDir); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
When building in my environment, the error

```
at line 42, file cache/local_fs.goundefined: err
at line 43, file cache/local_fs.goundefined: err
```

occured. Please review this @dtan4 
