### PR TITLE
Set any cache directory to get target path

### DIFF
--- a/cache/local_fs.go
+++ b/cache/local_fs.go
@@ -32,8 +32,8 @@ func NewLocalFsCache() Cache {
 }
 
 func (c *LocalFsCache) Get(key string) (string, error) {
-	cache := cachePath(key)
-	inflateDir := inflateDirPath(key)
+	cache := cachePath(c.cacheDir, key)
+	inflateDir := inflateDirPath(c.cacheDir, key)
 
 	if _, err := os.Stat(cache); err != nil {
 		return "", nil
@@ -47,17 +47,17 @@ func (c *LocalFsCache) Get(key string) (string, error) {
 }
 
 func (c *LocalFsCache) Put(key, directory string) error {
-	if err := DeflateTarGz(cachePath(key), directory); err != nil {
+	if err := DeflateTarGz(cachePath(c.cacheDir, key), directory); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func cachePath(key string) string {
-	return DefaultCacheDir + string(filepath.Separator) + key + ".tar.gz"
+func cachePath(cacheDir, key string) string {
+	return cacheDir + string(filepath.Separator) + key + ".tar.gz"
 }
 
-func inflateDirPath(key string) string {
-	return DefaultCacheDir + string(filepath.Separator) + key
+func inflateDirPath(cacheDir, key string) string {
+	return cacheDir + string(filepath.Separator) + key
 }


### PR DESCRIPTION
## WHY

`cachePath` and `inflateDirPath` always takes constant `DefaultCacheDir`
## WHAT

Set any cache directory to build `cachePath` and `inflateDirPath`
