### PR TITLE
Enable to specify registry backend

### DIFF
--- a/risu.go
+++ b/risu.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"time"
 
 	"code.google.com/p/go-uuid/uuid"
@@ -17,6 +18,7 @@ import (
 )
 
 var ren = render.New()
+var reg = registry.NewRegistry(os.Getenv("REGISTRY_BACKEND"), os.Getenv("REGISTRY_ENDPOINT"))
 
 func create(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	defer r.Body.Close()
@@ -41,7 +43,6 @@ func create(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 		UpdatedAt:      time.Now(),
 	}
 
-	reg := registry.NewRegistry("localfs", "")
 	reg.Set(build)
 
 	// debug code
@@ -54,7 +55,6 @@ func root(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 }
 
 func index(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-	reg := registry.NewRegistry("localfs", "")
 	builds, err := reg.List()
 	if err != nil {
 		ren.JSON(w, http.StatusInternalServerError, map[string]string{"status": "internal server error"})
@@ -66,7 +66,6 @@ func index(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 func show(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	id := ps.ByName("id")
 	uuid := uuid.Parse(id)
-	reg := registry.NewRegistry("localfs", "")
 	build, err := reg.Get(uuid)
 	if err != nil {
 		ren.JSON(w, http.StatusNotFound, map[string]string{"status": "not found"})

--- a/risu.go
+++ b/risu.go
@@ -44,7 +44,6 @@ func create(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 		UpdatedAt:      currentTime,
 	}
 
-	reg.Set(build)
 	err = reg.Set(build)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
## WHAT

Enable to specify registry backend via environment variables.
- `REGISTRY_BACKEND`: `localfs` or `etcd`
- `REGISTRY_ENDPOINT`:
  - `localfs`: directory path that build data files are stored in (c.f. `/tmp/risu`)
  - `etcd`: etcd's endpoint (c.f. `http://172.17.8.101:4001`)
## WHY

Enable risu user to switch the backend
