### PR TITLE
Return a single JSON

### DIFF
--- a/risu.go
+++ b/risu.go
@@ -58,9 +58,9 @@ func index(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	builds, err := reg.List()
 	if err != nil {
 		ren.JSON(w, http.StatusInternalServerError, map[string]string{"status": "internal server error"})
+	} else {
+		ren.JSON(w, http.StatusOK, builds)
 	}
-
-	ren.JSON(w, http.StatusOK, builds)
 }
 
 func show(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
@@ -70,8 +70,9 @@ func show(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	build, err := reg.Get(uuid)
 	if err != nil {
 		ren.JSON(w, http.StatusNotFound, map[string]string{"status": "not found"})
+	} else {
+		ren.JSON(w, http.StatusOK, build)
 	}
-	ren.JSON(w, http.StatusOK, build)
 }
 
 func main() {


### PR DESCRIPTION
## WHAT

Return a single JSON at any time

```
$ http localhost:8080/builds/1
HTTP/1.1 404 Not Found
Content-Length: 22
Content-Type: application/json; charset=UTF-8
Date: Fri, 14 Aug 2015 03:27:41 GMT

{
    "status": "not found"
}
```
## WHY

Server returns _two_ JSONs if something wrong was occurred.

```
$ http localhost:8080/builds/1
HTTP/1.1 404 Not Found
Content-Length: 179
Content-Type: application/json; charset=UTF-8
Date: Fri, 14 Aug 2015 03:19:55 GMT

{"status":"not found"}{"id":"","source_repo":"","source_revision":"","name":"","dockerfile":"","status":"","created_at":"0001-01-01T00:00:00Z","updated_at":"0001-01-01T00:00:00Z"}

$ http localhost:8080/builds/2
HTTP/1.1 404 Not Found
Content-Length: 179
Content-Type: application/json; charset=UTF-8
Date: Fri, 14 Aug 2015 03:19:58 GMT

{"status":"not found"}{"id":"","source_repo":"","source_revision":"","name":"","dockerfile":"","status":"","created_at":"0001-01-01T00:00:00Z","updated_at":"0001-01-01T00:00:00Z"}
```
