### PR TITLE
Change store directory with localfs backend registry

### DIFF
--- a/registry/localfs.go
+++ b/registry/localfs.go
@@ -11,7 +11,7 @@ import (
 )
 
 // DefaultFilePath is default file path
-const DefaultFilePath = "/tmp/risu/"
+const DefaultFilePath = "/etc/risu/"
 
 // LocalFsRegistry is sharing path
 type LocalFsRegistry struct {


### PR DESCRIPTION
## WHAT

Change store directory 
- `/tmp/risu` -> `/etc/risu`
## WHY

Because of build data is persistence data, storing it in `/tmp` isn't suitable.
