### PR TITLE
Add an attribute "cache_directories" to build

### DIFF
--- a/docs/api-v1-alpha.md
+++ b/docs/api-v1-alpha.md
@@ -9,10 +9,11 @@ A build represents an individual build job for docker image
 | Name | Type | Description | Example |
 | ------- | ------- | ------- | ------- |
 | **id** | *uuid* | unique identifier of build | `"01234567-89ab-cdef-0123-456789abcdef"` |
-| **source_repo** | *string* | source github source_repositry to build. It must includes Dockerfile | `"wantedly/risu"` |
+| **source_repo** | *string* | source github repositry to build. It must includes Dockerfile | `"wantedly/risu"` |
 | **source_branch** | *string* | git branch to use for build.<br/> **default:** `"master"` | `"master"` |
 | **name** | *string* | a repository name (and optionally a tag) to apply to the resulting image in case of success. | `"quay.io/wantedly/risu:latest"` |
 | **dockerfile** | *string* | path within the build context to the Dockerfile<br/> **default:** `"Dockerfile"` | `"Dockerfile.dev"` |
+| **cache_directories** | *array* | directory paths that you want to cache | `[{"source":"vendor/bundle","container":"/app/vendor/bundle"},{"source":"vendor/assets","container":"/app/vendor/assets"}]` |
 | **status** | *string* | status of build. one of "failed" or "building" or "succeeded" | `"succeeded"` |
 | **created_at** | *date-time* | when build was created | `"2015-01-01T12:00:00Z"` |
 | **updated_at** | *date-time* | when build was updated | `"2015-01-01T12:00:00Z"` |
@@ -29,10 +30,11 @@ POST /builds
 
 | Name | Type | Description | Example |
 | ------- | ------- | ------- | ------- |
-| **source_repo** | *string* | source github source_repositry to build. It must includes Dockerfile | `"wantedly/risu"` |
+| **source_repo** | *string* | source github repositry to build. It must includes Dockerfile | `"wantedly/risu"` |
 | **source_branch** | *string* | git branch to use for build.<br/> **default:** `"master"` | `"master"` |
 | **name** | *string* | a repository name (and optionally a tag) to apply to the resulting image in case of success. | `"quay.io/wantedly/risu:latest"` |
 | **dockerfile** | *string* | path within the build context to the Dockerfile<br/> **default:** `"Dockerfile"` | `"Dockerfile.dev"` |
+| **cache_directories** | *array* | directory paths that you want to cache | `[{"source":"vendor/bundle","container":"/app/vendor/bundle"},{"source":"vendor/assets","container":"/app/vendor/assets"}]` |
 
 
 #### Curl Example
@@ -45,7 +47,17 @@ $ curl -n -X POST https://<your-risu-server>.com/builds \
   "source_repo": "wantedly/risu",
   "source_branch": "master",
   "name": "quay.io/wantedly/risu:latest",
-  "dockerfile": "Dockerfile.dev"
+  "dockerfile": "Dockerfile.dev",
+  "cache_directories": [
+    {
+      "source": "vendor/bundle",
+      "container": "/app/vendor/bundle"
+    },
+    {
+      "source": "vendor/assets",
+      "container": "/app/vendor/assets"
+    }
+  ]
 }'
 ```
 
@@ -63,6 +75,16 @@ HTTP/1.1 201 Created
   "source_branch": "master",
   "name": "quay.io/wantedly/risu:latest",
   "dockerfile": "Dockerfile.dev",
+  "cache_directories": [
+    {
+      "source": "vendor/bundle",
+      "container": "/app/vendor/bundle"
+    },
+    {
+      "source": "vendor/assets",
+      "container": "/app/vendor/assets"
+    }
+  ],
   "status": "succeeded",
   "created_at": "2015-01-01T12:00:00Z",
   "updated_at": "2015-01-01T12:00:00Z"
@@ -98,6 +120,16 @@ HTTP/1.1 200 OK
   "source_branch": "master",
   "name": "quay.io/wantedly/risu:latest",
   "dockerfile": "Dockerfile.dev",
+  "cache_directories": [
+    {
+      "source": "vendor/bundle",
+      "container": "/app/vendor/bundle"
+    },
+    {
+      "source": "vendor/assets",
+      "container": "/app/vendor/assets"
+    }
+  ],
   "status": "succeeded",
   "created_at": "2015-01-01T12:00:00Z",
   "updated_at": "2015-01-01T12:00:00Z"
@@ -134,6 +166,16 @@ HTTP/1.1 200 OK
     "source_branch": "master",
     "name": "quay.io/wantedly/risu:latest",
     "dockerfile": "Dockerfile.dev",
+    "cache_directories": [
+      {
+        "source": "vendor/bundle",
+        "container": "/app/vendor/bundle"
+      },
+      {
+        "source": "vendor/assets",
+        "container": "/app/vendor/assets"
+      }
+    ],
     "status": "succeeded",
     "created_at": "2015-01-01T12:00:00Z",
     "updated_at": "2015-01-01T12:00:00Z"

--- a/registry/localfs.go
+++ b/registry/localfs.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"encoding/json"
 	"io/ioutil"
+	"log"
 	"os"
 
 	"code.google.com/p/go-uuid/uuid"
@@ -25,7 +26,9 @@ func NewLocalFsRegistry(path string) Registry {
 	}
 
 	if _, err := os.Stat(path); err != nil {
-		os.MkdirAll(path, 0755)
+		if err = os.MkdirAll(path, 0755); err != nil {
+			log.Fatal(err)
+		}
 	}
 	return &LocalFsRegistry{path}
 }

--- a/schema/build.go
+++ b/schema/build.go
@@ -7,21 +7,23 @@ import (
 )
 
 type Build struct {
-	ID           uuid.UUID `json:"id"`
-	SourceRepo   string    `json:"source_repo"`
-	SourceBranch string    `json:"source_branch"`
-	Name         string    `json:"name"`
-	Dockerfile   string    `json:"dockerfile"`
-	Status       string    `json:"status"`
-	CreatedAt    time.Time `json:"created_at"`
-	UpdatedAt    time.Time `json:"updated_at"`
+	ID               uuid.UUID           `json:"id"`
+	SourceRepo       string              `json:"source_repo"`
+	SourceBranch     string              `json:"source_branch"`
+	Name             string              `json:"name"`
+	Dockerfile       string              `json:"dockerfile"`
+	CacheDirectories []map[string]string `json:"cache_directories"`
+	Status           string              `json:"status"`
+	CreatedAt        time.Time           `json:"created_at"`
+	UpdatedAt        time.Time           `json:"updated_at"`
 }
 
 type BuildCreateOpts struct {
-	SourceRepo   string `json:"source_repo"`
-	SourceBranch string `json:"source_branch"`
-	Name         string `json:"name"`
-	Dockerfile   string `json:"dockerfile"`
+	SourceRepo       string              `json:"source_repo"`
+	SourceBranch     string              `json:"source_branch"`
+	Name             string              `json:"name"`
+	Dockerfile       string              `json:"dockerfile"`
+	CacheDirectories []map[string]string `json:"cache_directories"`
 }
 
 // NewBuild creates new build struct
@@ -36,13 +38,14 @@ func NewBuild(opts BuildCreateOpts) Build {
 
 	currentTime := time.Now()
 	return Build{
-		ID:           uuid.NewUUID(),
-		SourceRepo:   opts.SourceRepo,
-		SourceBranch: opts.SourceBranch,
-		Name:         opts.Name,
-		Dockerfile:   opts.Dockerfile,
-		Status:       "building",
-		CreatedAt:    currentTime,
-		UpdatedAt:    currentTime,
+		ID:               uuid.NewUUID(),
+		SourceRepo:       opts.SourceRepo,
+		SourceBranch:     opts.SourceBranch,
+		Name:             opts.Name,
+		Dockerfile:       opts.Dockerfile,
+		CacheDirectories: opts.CacheDirectories,
+		Status:           "building",
+		CreatedAt:        currentTime,
+		UpdatedAt:        currentTime,
 	}
 }

--- a/schema/schema.json
+++ b/schema/schema.json
@@ -31,7 +31,7 @@
           ]
         },
         "source_repo": {
-          "description": "source github source_repositry to build. It must includes Dockerfile",
+          "description": "source github repositry to build. It must includes Dockerfile",
           "required": "true,",
           "example": "wantedly/risu",
           "type": [
@@ -62,6 +62,28 @@
           "type": [
             "string"
           ]
+        },
+        "cache_directories": {
+          "description": "directory paths that you want to cache",
+          "required": true,
+          "example": [
+            {
+              "source": "vendor/bundle",
+              "container": "/app/vendor/bundle"
+            },
+            {
+              "source": "vendor/assets",
+              "container": "/app/vendor/assets"
+            }
+          ],
+          "type": [
+            "array"
+          ],
+          "items": {
+            "type": [
+              "object"
+            ]
+          }
         },
         "status": {
           "description": "status of build. one of \"failed\" or \"building\" or \"succeeded\"",
@@ -107,6 +129,9 @@
               },
               "dockerfile": {
                 "$ref": "#/definitions/build/definitions/dockerfile"
+              },
+              "cache_directories": {
+                "$ref": "#/definitions/build/definitions/cache_directories"
               }
             },
             "type": [
@@ -145,6 +170,9 @@
         },
         "dockerfile": {
           "$ref": "#/definitions/build/definitions/dockerfile"
+        },
+        "cache_directories": {
+          "$ref": "#/definitions/build/definitions/cache_directories"
         },
         "status": {
           "$ref": "#/definitions/build/definitions/status"

--- a/schema/schemata/build.yml
+++ b/schema/schemata/build.yml
@@ -18,7 +18,7 @@ definitions:
     type:
     - string
   source_repo:
-    description: source github source_repositry to build. It must includes Dockerfile
+    description: source github repositry to build. It must includes Dockerfile
     required: true,
     example: "wantedly/risu"
     type:
@@ -42,6 +42,17 @@ definitions:
     default: "Dockerfile"
     type:
     - string
+  cache_directories:
+    description: directory paths that you want to cache
+    required: true
+    example: [
+      { "source": "vendor/bundle", "container": "/app/vendor/bundle"},
+      { "source": "vendor/assets", "container": "/app/vendor/assets"},
+    ]
+    type:
+    - array
+    items:
+      type: object
   status:
     description: status of build. one of "failed" or "building" or "succeeded"
     readOnly: true
@@ -79,6 +90,9 @@ links:
       "dockerfile": {
         "$ref": "/schemata/build#/definitions/dockerfile"
       },
+      "cache_directories": {
+        "$ref": "/schemata/build#/definitions/cache_directories"
+      },
     }
     type:
     - object
@@ -104,6 +118,8 @@ properties:
     "$ref": "/schemata/build#/definitions/name"
   dockerfile:
     "$ref": "/schemata/build#/definitions/dockerfile"
+  cache_directories:
+    "$ref": "/schemata/build#/definitions/cache_directories"
   status:
     "$ref": "/schemata/build#/definitions/status"
   created_at:


### PR DESCRIPTION
## WHAT

`cache_directories` という attribute を build に追加した。
サンプルのリクエストは以下のようになる。

``` bash
$ curl -n -X POST https://<your-risu-server>.com/builds \
  -H "Content-Type: application/json" \
 \
  -d '{
  "source_repo": "wantedly/risu",
  "source_branch": "master",
  "name": "quay.io/wantedly/risu:latest",
  "dockerfile": "Dockerfile.dev",
  "cache_directories": [
    {
      "source": "vendor/bundle",
      "container": "/app/vendor/bundle"
    },
    {
      "source": "vendor/assets",
      "container": "/app/vendor/assets"
    }
  ]
}'
```
- `source` が指しているのは、`docker build` 前に source に cache を追加するときのパス（ソースリポジトリのルートディレクトリからの相対パスで指定）
- `container` が指しているのはイメージ作成後に次回のキャッシュとして使いたいディレクトリのパス（コンテナ内の絶対パスで指定）
## WHY

この情報がリクエストに含まれていないと、ソースリポジトリのどこにキャッシュを追加してあげればよいか、またできたイメージのどこをキャッシュとして残してあげればよいかわからないため。
