### PR TITLE
Run 'git submodule update --init' after clone

### DIFF
--- a/risu.go
+++ b/risu.go
@@ -109,6 +109,7 @@ func checkoutGitRepository(build schema.Build, dir string) error {
 	fmt.Println(clonePath)
 
 	shell.Command("git", "clone", cloneURL, clonePath)
+	shell.CommandInDir(clonePath, "git", "submodule", "update", "--init")
 	shell.CommandInDir(clonePath, "git", "fetch", "origin", build.SourceBranch)
 	shell.CommandInDir(clonePath, "git", "checkout", "remotes/origin/"+build.SourceBranch, "-f")
 	return nil

--- a/risu.go
+++ b/risu.go
@@ -109,9 +109,9 @@ func checkoutGitRepository(build schema.Build, dir string) error {
 	fmt.Println(clonePath)
 
 	shell.Command("git", "clone", cloneURL, clonePath)
-	shell.CommandInDir(clonePath, "git", "submodule", "update", "--init")
 	shell.CommandInDir(clonePath, "git", "fetch", "origin", build.SourceBranch)
 	shell.CommandInDir(clonePath, "git", "checkout", "remotes/origin/"+build.SourceBranch, "-f")
+	shell.CommandInDir(clonePath, "git", "submodule", "update", "--init")
 	return nil
 }
 


### PR DESCRIPTION
To build the repository which has git submodule, we need to update git submodule. To handle this case, execute `git submodule update --init` after checking out the target repository.

`git submodule update --init` is safe even if submodule is already updated or no submodule is included.

cc: @spesnova @dtan4 
