### PR TITLE
Delete expired items at LocalFS backend registry

### DIFF
--- a/registry/local_fs.go
+++ b/registry/local_fs.go
@@ -121,9 +121,9 @@ func deleteExpiredItem(path string, f os.FileInfo, _ error) error {
 		return nil
 	}
 
-	currentTime := time.Now()
+	elapsedSeconds := time.Now().Sub(f.ModTime()).Seconds()
 
-	if currentTime.Sub(f.ModTime()).Seconds() > DefaultExpireSeconds {
+	if elapsedSeconds > DefaultExpireSeconds {
 		if err := os.Remove(path); err != nil {
 			return err
 		}

--- a/registry/local_fs.go
+++ b/registry/local_fs.go
@@ -5,6 +5,8 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
+	"time"
 
 	"code.google.com/p/go-uuid/uuid"
 
@@ -30,6 +32,17 @@ func NewLocalFsRegistry(dir string) Registry {
 			log.Fatal(err)
 		}
 	}
+
+	go func(dir string) {
+		for {
+			if err := cleanUpItems(dir); err != nil {
+				log.Fatal(err)
+			}
+
+			time.Sleep(10 * time.Second)
+		}
+	}(dir)
+
 	return &LocalFsRegistry{dir}
 }
 
@@ -101,4 +114,28 @@ func (r *LocalFsRegistry) List() ([]schema.Build, error) {
 	}
 
 	return builds, nil
+}
+
+func deleteExpiredItem(path string, f os.FileInfo, _ error) error {
+	if f.IsDir() {
+		return nil
+	}
+
+	currentTime := time.Now()
+
+	if currentTime.Sub(f.ModTime()).Seconds() > DefaultExpireSeconds {
+		if err := os.Remove(path); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func cleanUpItems(dir string) error {
+	if err := filepath.Walk(dir, deleteExpiredItem); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -6,6 +6,10 @@ import (
 	"github.com/wantedly/risu/schema"
 )
 
+const (
+	DefaultExpireSeconds = 60 * 60 * 24 * 5 // 5 days
+)
+
 type Registry interface {
 	Set(build schema.Build) error
 	Get(id uuid.UUID) (schema.Build, error)


### PR DESCRIPTION
## WHY

To avoid increasing registry size
## WHAT

Delete old registry files on LocalFS backend registry every 10 seconds. Default expiration period is 5 days.
