### PR TITLE
Hide clone URL from log

### DIFF
--- a/risu.go
+++ b/risu.go
@@ -118,9 +118,6 @@ func checkoutGitRepository(build schema.Build, dir string) error {
 	// htpps://<token>@github.com/<SourceRepo>.git
 	cloneURL := "https://" + os.Getenv("GITHUB_ACCESS_TOKEN") + "@github.com/" + build.SourceRepo + ".git"
 
-	// debug
-	fmt.Println(cloneURL)
-
 	clonePath := dir + build.SourceRepo
 
 	// debug
@@ -139,7 +136,6 @@ func refreshCache(build schema.Build) error {
 	if err != nil {
 		return err
 	}
-
 
 	if err = putCache(build, saveBaseDir); err != nil {
 		return err


### PR DESCRIPTION
## WHY

Because clone URL includes `GITHUB_ACCESS_TOKEN`.

``` bash
$ ./risu
[negroni] listening on :8080
[negroni] Started POST /builds
[negroni] Completed 202 Accepted in 4.937515ms
https://<GITHUB_ACCESS_TOKEN>@github.com/wantedly/private-nginx-image-server.git
/var/risu/src/github.com/wantedly/private-nginx-image-server
```
