### PR TITLE
Print log with build ID

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -52,7 +52,7 @@ func dockerBuild(build schema.Build) error {
 	opts := docker.BuildImageOptions{
 		Name:                build.ImageName,
 		NoCache:             false,
-		SuppressOutput:      true,
+		SuppressOutput:      false,
 		RmTmpContainer:      true,
 		ForceRmTmpContainer: true,
 		Dockerfile:          build.Dockerfile,

--- a/log.go
+++ b/log.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"log"
+
+	"github.com/wantedly/risu/schema"
+)
+
+func printLog(build schema.Build, text string) {
+	log.Printf("[%s] %s\n", build.ID.String(), text)
+}

--- a/risu.go
+++ b/risu.go
@@ -115,7 +115,7 @@ func show(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 func checkoutGitRepository(build schema.Build, dir string) error {
 	if _, err := os.Stat(dir); err != nil {
 		if err := os.MkdirAll(dir, 0755); err != nil {
-			log.Fatal(err)
+			printLog(build, err.Error())
 		}
 	}
 

--- a/risu.go
+++ b/risu.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -59,25 +58,30 @@ func create(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 
 		if err := dockerBuild(build); err != nil {
 			if err := reg.Set(build, schema.BuildUpdateOpts{Status: "failed to build"}); err != nil {
-				log.Print(err)
+				printLog(build, err.Error())
 			}
+
+			printLog(build, err.Error())
 			return
 		}
 		if err := reg.Set(build, schema.BuildUpdateOpts{Status: "build completed and pushing"}); err != nil {
-			log.Print(err)
+			printLog(build, err.Error())
 		}
 
 		if err := dockerPush(build); err != nil {
 			if err := reg.Set(build, schema.BuildUpdateOpts{Status: "failed to push"}); err != nil {
-				log.Print(err)
+				printLog(build, err.Error())
 			}
+
+			printLog(build, err.Error())
 			return
 		}
 		if err := reg.Set(build, schema.BuildUpdateOpts{Status: "build completed and pushed"}); err != nil {
-			log.Print(err)
+			printLog(build, err.Error())
 		}
 
 		if err := refreshCache(build); err != nil {
+			printLog(build, err.Error())
 			return
 		}
 	}()
@@ -121,7 +125,7 @@ func checkoutGitRepository(build schema.Build, dir string) error {
 	clonePath := dir + build.SourceRepo
 
 	// debug
-	fmt.Println(clonePath)
+	printLog(build, clonePath)
 
 	shell.Command("git", "clone", cloneURL, clonePath)
 	shell.CommandInDir(clonePath, "git", "fetch", "origin", build.SourceBranch)


### PR DESCRIPTION
## WHY

Currently intermediate logs (git clone, docker build ...) are not printed. It is hard to inspect error.
## WHAT

Print intermediate log with build id in server log. This patch enables risu to print `docker build` logs.

```
web_1 | 2015/08/18 06:40:47 Error loading .env file
web_1 | [negroni] listening on :8080
web_1 | [negroni] Started POST /builds
web_1 | [negroni] Completed 202 Accepted in 610.525µs
web_1 | 2015/08/18 06:40:51 [1165e076-4574-11e5-b36f-02420a01001b] /var/risu/src/github.com/wantedly/wantedly
web_1 | 2015/08/18 06:43:19 [1165e076-4574-11e5-b36f-02420a01001b] Step 0 : FROM ruby:2.1.5-slim
web_1 | 2015/08/18 06:43:19 [1165e076-4574-11e5-b36f-02420a01001b]  ---> 8e52dfe66e60
web_1 | 2015/08/18 06:43:19 [1165e076-4574-11e5-b36f-02420a01001b] Step 1 : MAINTAINER Seigo Uchida <spesnova@gmail.com> (@spesnova)
web_1 | 2015/08/18 06:43:19 [1165e076-4574-11e5-b36f-02420a01001b]  ---> Using cache
web_1 | 2015/08/18 06:43:19 [1165e076-4574-11e5-b36f-02420a01001b]  ---> 6e0f47c448e8
web_1 | 2015/08/18 06:43:19 [1165e076-4574-11e5-b36f-02420a01001b] Step 2 : RUN apt-get update &&     apt-get install -y       git       imagemagick       libmagickwand-dev       libxrender1       libfontconfig1       libpq-dev       fonts-ipafont-mincho       libicu-dev       cmake       g++       nodejs &&     rm -rf /var/lib/apt/lists/*
web_1 | 2015/08/18 06:43:19 [1165e076-4574-11e5-b36f-02420a01001b]  ---> Using cache
web_1 | 2015/08/18 06:43:19 [1165e076-4574-11e5-b36f-02420a01001b]  ---> cfb3c3b21500
web_1 | 2015/08/18 06:43:19 [1165e076-4574-11e5-b36f-02420a01001b] Step 3 : ENV RACK_ENV production
web_1 | 2015/08/18 06:43:19 [1165e076-4574-11e5-b36f-02420a01001b]  ---> Using cache
web_1 | 2015/08/18 06:43:19 [1165e076-4574-11e5-b36f-02420a01001b]  ---> 1ad89dc69f48
```
