### PR TITLE
mkdir DefaultInflatedCacheDir

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -84,6 +84,13 @@ func extractCache(build schema.Build) (string, error) {
 
 	saveBaseDir := c.DefaultInflatedCacheDir + getCacheKey(build.SourceRepo) + "/"
 
+	// make directory
+	if _, err := os.Stat(c.DefaultInflatedCacheDir); err != nil {
+		if err = os.MkdirAll(c.DefaultInflatedCacheDir, 0755); err != nil {
+			return "", err
+		}
+	}
+
 	for _, cacheDirectory := range build.CacheDirectories {
 		outputbuf := bytes.NewBuffer(nil)
 


### PR DESCRIPTION
## REF

https://github.com/wantedly/risu/issues/59
## WHY

because of resolve error

```
no such file or directory
```

```
2015/08/18 11:28:22 [e036895e-459b-11e5-ac54-02420a010006] open /tmp/risu/bec1fdf812ba.tar.gz: no such file or directory
```
## WHAT

mkdir base directory

cc: @wantedly/infrastructure 
