### PR TITLE
Mount /var/run/docker.sock from Docker host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,4 +3,6 @@ web:
   env_file: .env
   ports:
     - "8080:8080"
+  volumes:
+    - "/var/run/docker.sock:/var/run/docker.sock"
   command: /bin/risu


### PR DESCRIPTION
## WHY

To run risu easily by Docker Compose. /var/run/docker.sock is required to run Docker on the container.
## WHAT

Mount /var/run/docker.sock on the container from Docker host
