### PR TITLE
Return 500 error message and keep server alive

### DIFF
--- a/risu.go
+++ b/risu.go
@@ -38,15 +38,15 @@ func create(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	var opts schema.BuildCreateOpts
 	err := json.NewDecoder(r.Body).Decode(&opts)
 	if err != nil {
-		log.Fatal(err)
-		ren.JSON(w, http.StatusInternalServerError, map[string]string{"status": "internal server error"})
+		log.Println(err)
+		ren.JSON(w, http.StatusInternalServerError, map[string]string{"status": "internal server error: " + err.Error()})
 		return
 	}
 
 	build, err := reg.Create(opts)
 	if err != nil {
-		log.Fatal(err)
-		ren.JSON(w, http.StatusInternalServerError, map[string]string{"status": "internal server error"})
+		log.Println(err)
+		ren.JSON(w, http.StatusInternalServerError, map[string]string{"status": "internal server error: " + err.Error()})
 		return
 	}
 	ren.JSON(w, http.StatusAccepted, build)


### PR DESCRIPTION
Close #63 
## WHY

Currently server deads before return 500 error.
## WHAT

When something wrong is happen in server, return 500 and error message to HTTP client.

``` bash
# client
$ curl -v -XPOST -H "Content-Type: application/json" localhost:8080/builds
* Hostname was NOT found in DNS cache
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 8080 (#0)
> POST /builds HTTP/1.1
> User-Agent: curl/7.37.1
> Host: localhost:8080
> Accept: */*
> Content-Type: application/json
>
< HTTP/1.1 500 Internal Server Error
< Content-Type: application/json; charset=UTF-8
< Date: Mon, 24 Aug 2015 09:59:29 GMT
< Content-Length: 39
<
* Connection #0 to host localhost left intact
{"status":"internal server error: EOF"}%
```

``` bash
# server
$ ./risu
[negroni] listening on :8080
[negroni] Started POST /builds
2015/08/24 18:58:26 EOF
[negroni] Completed 500 Internal Server Error in 460.377µs
```
