### PR TITLE
Parse image name with port except 80

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -149,7 +149,7 @@ func dockerPush(build schema.Build) error {
 	} else {
 		tag := build.ImageName[idx+1:]
 
-		if !strings.Contains(tag, "/") {
+		if strings.Contains(tag, "/") {
 			dockerRegistry = strings.Split(build.ImageName, "/")[0]
 			dockerImageName = strings.Join(strings.Split(build.ImageName, "/")[1:], "/")
 			dockerImageTag = "latest"

--- a/docker.go
+++ b/docker.go
@@ -147,9 +147,17 @@ func dockerPush(build schema.Build) error {
 		dockerImageName = strings.Join(strings.Split(build.ImageName, "/")[1:], "/")
 		dockerImageTag = "latest"
 	} else {
-		dockerRegistry = strings.Split(build.ImageName[:idx], "/")[0]
-		dockerImageName = strings.Join(strings.Split(build.ImageName[:idx], "/")[1:], "/")
-		dockerImageTag = build.ImageName[idx+1:]
+		tag := build.ImageName[idx+1:]
+
+		if !strings.Contains(tag, "/") {
+			dockerRegistry = strings.Split(build.ImageName, "/")[0]
+			dockerImageName = strings.Join(strings.Split(build.ImageName, "/")[1:], "/")
+			dockerImageTag = "latest"
+		} else {
+			dockerRegistry = strings.Split(build.ImageName[:idx], "/")[0]
+			dockerImageName = strings.Join(strings.Split(build.ImageName[:idx], "/")[1:], "/")
+			dockerImageTag = tag
+		}
 	}
 
 	logsReader, outputbuf := io.Pipe()

--- a/docker.go
+++ b/docker.go
@@ -140,16 +140,16 @@ func dockerPush(build schema.Build) error {
 		return err
 	}
 
-	n := strings.LastIndex(build.ImageName, ":")
+	idx := strings.LastIndex(build.ImageName, ":")
 
-	if n < 0 {
+	if idx < 0 {
 		dockerRegistry = strings.Split(build.ImageName, "/")[0]
 		dockerImageName = strings.Join(strings.Split(build.ImageName, "/")[1:], "/")
 		dockerImageTag = "latest"
 	} else {
-		dockerRegistry = strings.Split(build.ImageName[:n], "/")[0]
-		dockerImageName = strings.Join(strings.Split(build.ImageName[:n], "/")[1:], "/")
-		dockerImageTag = build.ImageName[n+1:]
+		dockerRegistry = strings.Split(build.ImageName[:idx], "/")[0]
+		dockerImageName = strings.Join(strings.Split(build.ImageName[:idx], "/")[1:], "/")
+		dockerImageTag = build.ImageName[idx+1:]
 	}
 
 	logsReader, outputbuf := io.Pipe()


### PR DESCRIPTION
## WHY

Currently RISU cannot parse image name including port like 5050:

``` bash
# localhost:5000/wantedly/wantedly:latest
Error pushing to registry: Tag does not exist: 5000/wantedly/wantedly
```
## WHAT

Enable to parse image name with port number
